### PR TITLE
Travis config update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ jobs:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - gcc-7
-      env: COMPILER=gcc-7
+            - g++-7
+      env: COMPILER=g++-7
     - os: linux
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,9 @@ script:
 - $COMPILER -v
 - cppcheck --quiet --error-exitcode=1 .
 - mkdir build && cd build
-- cmake -DCMAKE_CXX_COMPILER=$COMPILER -DCMAKE_BUILD_TYPE=Coverage .. && make -j4
+- cmake -DCMAKE_CXX_COMPILER=$COMPILER .. && make -j4
 - cd src
 - ./travis_test
 - cd ../test
 - ./example_test
 - cd ..
-- make coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-7
-      env: COMPILER=gcc-7.4.0
+      env: COMPILER=gcc-7
     - os: linux
       addons:
         apt:
@@ -20,7 +20,7 @@ jobs:
             - llvm-toolchain-precise-6.0
           packages:
             - clang-6.0
-      env: COMPILE=clang++-6.0
+      env: COMPILER=clang++-6.0
 
 notifications:
   email: false
@@ -32,6 +32,7 @@ install:
 - sudo apt-get install -qq cppcheck qt5-default qtbase5-dev lcov
 
 script:
+- $COMPILER -v
 - cppcheck --quiet --error-exitcode=1 .
 - mkdir build && cd build
 - cmake -DCMAKE_CXX_COMPILER=$COMPILER -DCMAKE_BUILD_TYPE=Coverage .. && make -j4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
-language: c++
+language: cpp
+os: linux
+dist: xenial
 
-matrix:
+jobs:
   include:
     - os: linux
       addons:
@@ -9,7 +11,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-7
-          env: COMPILER=gcc-7.4.0
+      env: COMPILER=gcc-7.4.0
     - os: linux
       addons:
         apt:
@@ -18,12 +20,12 @@ matrix:
             - llvm-toolchain-precise-6.0
           packages:
             - clang-6.0
-          env: COMPILER=clang++-6.0
+      env: COMPILE=clang++-6.0
 
-notification:
+notifications:
   email: false
 
-befor_install:
+before_install:
 - sudo apt-get update -qq
 
 install:
@@ -39,4 +41,3 @@ script:
 - ./example_test
 - cd ..
 - make coverage
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,34 +8,17 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-4.9
-          env: COMPILER=g++-4.9
+            - gcc-7
+          env: COMPILER=gcc-7.4.0
     - os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-6.0
           packages:
-            - g++-6
-          env: COMPILER=g++-6
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
-          packages:
-            - clang-3.6
-          env: COMPILER=clang++-3.6
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - clang-3.7
-          env: COMPILER=clang++-3.7
+            - clang-6.0
+          env: COMPILER=clang++-6.0
 
 notification:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,14 +1,4 @@
 # travis_playground
-[![Build Status](https://travis-ci.org/NorbertFenk/travis_playground.svg?branch=master)](https://travis-ci.org/NorbertFenk/travis_playground)
+[![Build Status](https://travis-ci.org/simonmatyi/travis_playground.svg?branch=master)](https://travis-ci.org/simonmatyi/travis_playground)
 
-This is a playground project to gather info about Travis CI.
-
-Resources:
-* https://crascit.com/2015/07/25/cmake-gtest/
-* https://github.com/Crascit/DownloadProject
-* http://david-grs.github.io/cpp-clang-travis-cmake-gtest-coveralls-appveyor/
-* https://github.com/david-grs/clang_travis_cmake_gtest_coveralls_example
-* https://arne-mertz.de/2017/04/continuous-integration-travis-ci/
-* https://github.com/richelbilderbeek/travis_cpp_tutorial
-* https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake
-* https://codeflu.blog/2014/12/26/using-gcov-and-lcov-to-generate-beautiful-c-code-coverage-statistics/
+This is a fork of the [playground project](https://github.com/NorbertFenk/travis_playground) of Norbert Fenk to gather info about Travis CI.


### PR DESCRIPTION
- Removed unnecessary compilation setups
- Set g++ version (7.4.0 gets installed on Travis when g++-7 is installed)
- Set clang version to 6.0
- Removed coverage run